### PR TITLE
Hooks into the bundling process

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ bundleSpec.withExternalModuleMapping('moment', 'momentjs:momentjs2');
 Of course your "app" bundle may depend on a number of weighty [Framework lib]s that you would prefer not to
 include in your bundle. If so, simply call `withExternalModuleMapping` for each.
 
+> Note that you can apply global mappings by calling `withExternalModuleMapping` on the top level `builder` instance. This is useful if you are creating multiple bundles, many/all of which are using the same external module mappings.
+
 ### Step 4.1 (Optional): Generating a "no_imports" bundle
 
 Externalizing commons [Framework lib]s (<a href="#step-4-optional-specify-external-module-mappings-imports">see Step 4</a>)
@@ -285,6 +287,26 @@ Or, by passing `--minify` on the command line. This will result in the minificat
  
 ```sh
 $ gulp --minify
+```
+
+## onPreBundle listeners
+
+There are times when you will need access to the underlying [Browserify] `bundler` just before the
+bundling process is executed (e.g. for adding transforms etc).
+
+To do this, you call the `onPreBundle` function. This function takes a `listener` function as an argument.
+This `listener` function, when called, receives the `bundle` as `this` and the `bundler` as the only argument to
+the supplied `listener`.
+
+```javascript
+var builder = require('@jenkins-cd/js-builder');
+
+builder.onPreBundle(function(bundler) {
+    var bundle = this;
+    
+    console.log('Adding the funky transform to bundler for bundle: ' + bundle.as);
+    bundler.transform(myFunkyTransform);
+});
 ```
 
 # Setting 'src' and 'test' (spec) paths

--- a/README.md
+++ b/README.md
@@ -228,8 +228,6 @@ include in your bundle. If so, simply call `withExternalModuleMapping` for each.
 
 ### Step 4.1 (Optional): Generating a "no_imports" bundle
 
-> _since_: 0.0.34
-
 Externalizing commons [Framework lib]s (<a href="#step-4-optional-specify-external-module-mappings-imports">see Step 4</a>)
 is important in terms of producing a JavaScript [bundle] that can be used in production (is lighter etc), but can make
 things a bit trickier when it comes to Integration Testing your bundle because your test (and test environment) will now need to
@@ -276,8 +274,6 @@ It would need to:
 See __Step 4__ above.  
 
 ## Step 6 (Optional): Minify bundle JavaScript
-
-> _since_: 0.0.35
 
 This can be done by calling `minify` on `js-builder`:
 
@@ -327,8 +323,6 @@ A number of `js-builder` options can be specified on the command line.
 
 ## `--minify`
 
-> _since_: 0.0.35
-
 Passing `--minify` on the command line will result in the minification of all generated bundles.
  
 ```sh
@@ -337,7 +331,6 @@ $ gulp --minify
 
 ## `--test`
 
-> _since_: 0.0.35
 
 Run a single test.
  

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,12 @@
 var builder = require('./index.js');
 
+// Create a mock bundle for abcxyz:abcxyzV2. We then use
+// this for testing the global withExternalModuleMapping
+builder.bundle('spec/abcxyzV2.js', 'abcxyzV2')
+    .inDir('jenkins/plugin/abcxyz/jsmodules');
+
+builder.withExternalModuleMapping('abcxyz', 'abcxyz:abcxyzV2');
+
 // Create some test bundles and check them in the specs
 
 //  - No imports 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var cwd = process.cwd();
 var hasJenkinsJsModulesDependency = dependencies.hasJenkinsJsModulesDep();
 
 var bundles = []; // see exports.bundle function
-var bundleDependencyTaskNames = ['log-env'];
+var bundleDependencyTaskNames = ['log-env', 'js-extensions'];
 
 var adjunctBasePath = './target/generated-adjuncts/';
 var jsmodulesBasePath = './src/main/webapp/jsmodules/';
@@ -48,6 +48,10 @@ exports.defineTasks = function(tasknames) {
         logger.logInfo("Source Dirs:");
         logger.logInfo(" - src: " + paths.srcPaths);
         logger.logInfo(" - test: " + paths.testSrcPath);    
+    });
+    gulp.task('js-extensions', function() {
+        var jsextensions = require('./internal/jsextensions');
+        jsextensions.processExtensionPoints(exports);
     });
 
     var defaults = [];
@@ -689,6 +693,3 @@ function hasSourceFiles(ext) {
 
 // Defined default tasks. Can be overridden.
 exports.defineTasks(['jshint', 'test', 'bundle', 'rebundle']);
-
-jsextensions = require('./internal/jsextensions');
-jsextensions.processExtensionPoints(exports);

--- a/index.js
+++ b/index.js
@@ -139,6 +139,20 @@ exports.withExternalModuleMapping = function(from, to, config) {
     return exports;
 };
 
+var preBundleListeners = [];
+/**
+ * Add a listener to be called just before Browserify starts bundling.
+ * <p>
+ * The listener is called with the {@code bundle} as {@code this} and
+ * the {@code bundler} as as the only arg.
+ * 
+ * @param listener The listener to add.
+ */
+exports.onPreBundle = function(listener) {
+    preBundleListeners.push(listener);
+    return exports;
+};
+
 function normalizePath(path) {
     path = _string.ltrim(path, './');
     path = _string.ltrim(path, '/');
@@ -417,6 +431,10 @@ exports.bundle = function(moduleToBundle, as) {
                     map: sourceMap,
                     output: bundleTo + '/' + sourceMap
                 });
+            }
+            
+            for (var i = 0; i < preBundleListeners.length; i++) {
+                preBundleListeners[i].call(bundle, bundler);
             }
             
             return bundler.bundle().pipe(source(bundle.bundleOutputFile))

--- a/spec/abcxyzV2.js
+++ b/spec/abcxyzV2.js
@@ -1,0 +1,2 @@
+var jsModules = require('@jenkins-cd/js-modules');
+jsModules.export('abcxyz', 'abcxyzV2', {});

--- a/spec/index-spec.js
+++ b/spec/index-spec.js
@@ -19,8 +19,9 @@ describe("index.js", function () {
             
             // Make sure all the scripts were loaded as expected.
             expect(browser.success).toBe(true);
-            expect(jsLoads.length).toBe(1);
+            expect(jsLoads.length).toBe(2);
             expect(jsLoads[0]).toBe('http://localhost:18999/target/testmodule/testmodule_1.js');
+            expect(jsLoads[1]).toBe('http://localhost:18999/jenkins/plugin/abcxyz/jsmodules/abcxyzV2.js');
             
             // Make sure the bundle executed...
             expect(browser.window.testmoduleXYZ).toBe('Hello');
@@ -46,9 +47,10 @@ describe("index.js", function () {
             
             // Make sure all the scripts were loaded as expected.
             expect(browser.success).toBe(true);
-            expect(jsLoads.length).toBe(2);
+            expect(jsLoads.length).toBe(3);
             expect(jsLoads[0]).toBe('http://localhost:18999/target/testmodule/testmodule_2.js');
-            expect(jsLoads[1]).toBe('http://localhost:18999/jenkins/plugin/underscore/jsmodules/under_string2.js'); // loading of the dependency
+            expect(jsLoads[1]).toBe('http://localhost:18999/jenkins/plugin/abcxyz/jsmodules/abcxyzV2.js');
+            expect(jsLoads[2]).toBe('http://localhost:18999/jenkins/plugin/underscore/jsmodules/under_string2.js'); // loading of the dependency
 
             // Shouldn't be any css loaded
             browser.assert.elements('link', 0);
@@ -77,9 +79,10 @@ describe("index.js", function () {
             
             // Make sure all the scripts were loaded as expected.
             expect(browser.success).toBe(true);
-            expect(jsLoads.length).toBe(2);
+            expect(jsLoads.length).toBe(3);
             expect(jsLoads[0]).toBe('http://localhost:18999/target/testmodule/testmodule_3.js');
-            expect(jsLoads[1]).toBe('http://localhost:18999/jenkins/plugin/underscore/jsmodules/under_string2.js'); // loading of the dependency
+            expect(jsLoads[1]).toBe('http://localhost:18999/jenkins/plugin/abcxyz/jsmodules/abcxyzV2.js');
+            expect(jsLoads[2]).toBe('http://localhost:18999/jenkins/plugin/underscore/jsmodules/under_string2.js'); // loading of the dependency
 
             // Should be css on page
             browser.assert.elements('link', 1);


### PR DESCRIPTION
- [x] Support global `withExternalMappingModule` settings.
- [x] Provide access to the browserify `bundler` just before the bundle is generated. Allows you to add transformers etc.
- [x] README updates