### PR TITLE
fix BO plugins can not build on windows.

### DIFF
--- a/internal/bundlegen.js
+++ b/internal/bundlegen.js
@@ -159,8 +159,10 @@ exports.doJSBundle = function(bundle, applyImports) {
             //
             var fileToBasename = path.basename(fileToBundle);
             var wrapperFileName = wrapperFileDir + '/_js_wrapper-' + fileToBasename;
+            var relativePath = path.relative(wrapperFileDir, fileToBundle);
+            relativePath = relativePath.replace(/\\/g, '/');
             var wrapperFileContent = entryModuleWrapperTemplate({
-                entrymodule: './' + path.relative(wrapperFileDir, fileToBundle),
+                entrymodule: './' + relativePath,
                 hpiPluginId: (maven.isHPI() ? maven.getArtifactId() : undefined),
                 startupModules: relativeStartupModules
             });


### PR DESCRIPTION
Fixes an issue where building BO plugins on windows fails when requiring something with a path

@kzantow this seems to fix my build issue, allthough I do get an error about duplicate mapping the plugin seems to work ok.

```
[INFO] [18:34:32] Using gulpfile C:\workarea\source\github\cloudbees\bluesteel-poc\cje-plugin\node_modules\@jenkins-cd\js-builder\res\cli-gulpfile.js
[INFO] [18:34:32] Starting 'log-env'...
[INFO] [18:34:32] Source Dirs:
[INFO] [18:34:32]  - src: src/main/js,src/main/less
[INFO] [18:34:32]  - test: src/test/js
[INFO] [18:34:32] Finished 'log-env' after 412 Î¼s
[INFO] [18:34:32] Starting 'js_bundle_react-router-3-0-0_bundle_1'...
[INFO] [18:34:32] Will use babel config from .babelrc
[INFO] [18:34:33] Starting 'js_bundle_jenkins-js-extension_bundle_2'...
[INFO] [18:34:33] Will use babel config from .babelrc
[INFO] [18:34:38] Finished 'js_bundle_react-router-3-0-0_bundle_1' after 6.36 s
[INFO] [18:34:41] Cannot map module "react-router". Multiple bundle map entries are known by this name (in different contexts).
[INFO] [18:34:41] Finished 'js_bundle_jenkins-js-extension_bundle_2' after 8.93 s
[INFO] [18:34:41] Starting 'bundle'...
[INFO] [18:34:41] bundling: done
```
