### PR TITLE
Log original error to console on bundle load failure

### DIFF
--- a/internal/templates/entry-module-wrapper.js
+++ b/internal/templates/entry-module-wrapper.js
@@ -22,6 +22,7 @@ promise.make(function(fulfill) {
         var startupModule = require('{{this}}');
         startupModule.execute(fulfill, config);
     } catch (e) {
+        console.error(e);
         throw new Error('Unexpected error executing startup module "{{this}}": ' + e);
     }
 }).onFulfilled(function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder",
-  "version": "0.0.54",
+  "version": "0.0.54-SNAPSHOT",
   "description": "Jenkins CI JavaScript Build utilities.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "Jenkins CI JavaScript Build utilities.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Log original error to console on bundle load failure so user can see correct stack trace.