### PR TITLE
fix bug where gulp-mocha can hang after test run

### DIFF
--- a/internal/tests.js
+++ b/internal/tests.js
@@ -119,6 +119,9 @@ function mochaTestTask() {
                 return;
             }
             process.exit(1);
+        }) // https://github.com/sindresorhus/gulp-mocha#test-suite-not-exiting
+        .once('end', function () {
+          process.exit();
         });
 }
 


### PR DESCRIPTION
Fixes bug where `gulp-mocha` can fail to exit after a test run https://github.com/sindresorhus/gulp-mocha#test-suite-not-exiting 

PTAL @tfennelly @cliffmeyers 

Accidentally had opened this against the wrong fork https://github.com/tfennelly/jenkins-js-builder/pull/2 