### PR TITLE
Dump bundle info

### DIFF
--- a/internal/adjunctexternal.js
+++ b/internal/adjunctexternal.js
@@ -7,6 +7,7 @@ var ModuleSpec = require('@jenkins-cd/js-modules/js/ModuleSpec');
 var cwd = process.cwd();
 var templates = require('./templates');
 var exportModuleTemplate = templates.getTemplate('export-module.hbs');
+var args = require('./args');
 
 exports.bundleFor = function(builder, packageName) {
     var packageSpec = new ModuleSpec(packageName);
@@ -26,8 +27,8 @@ exports.bundleFor = function(builder, packageName) {
     var jsModuleNames = extVersionMetadata.jsModuleNames;
     var installedVersion = extVersionMetadata.installedVersion;
     var inDir = 'target/classes/org/jenkins/ui/jsmodules/' + normalizedPackageName;
-    
-    if (!fs.existsSync(cwd + '/' + inDir + '/' + jsModuleNames.filenameFor(installedVersion) + '.js')) {
+
+    if (args.isArgvSpecified('--forceBundleGen') || !fs.existsSync(cwd + '/' + inDir + '/' + jsModuleNames.filenameFor(installedVersion) + '.js')) {
         // We need to generate an adjunct bundle for the package.
         var bundleSrc = generateBundleSrc(extVersionMetadata);
         builder.bundle(bundleSrc, packageName + '@' + installedVersion.asBaseVersionString())
@@ -37,7 +38,7 @@ exports.bundleFor = function(builder, packageName) {
     } else {
         // The bundle has already been generated. No need to do it again.
         // For linked modules ... do an rm -rf of the target dir ... sorry :)
-        logger.logInfo('Bundle for "' + packageName + '" already created. Delete "target" directory ad run bundle again to recreate.');
+        logger.logInfo('Bundle for "' + packageName + '" already created. Delete "target" directory and run bundle again to recreate.');
     }
 
     return extVersionMetadata.importAs();

--- a/internal/bundlegen.js
+++ b/internal/bundlegen.js
@@ -268,7 +268,7 @@ exports.doJSBundle = function(bundle, applyImports) {
         var bufferedTextTransform = require('./pipeline-transforms/buffered-text-accumulator-transform');
         var requireStubTransform = require('./pipeline-transforms/require-stub-transform');
         var pack = require('browser-pack');
-        var bundleInfoOutFile = bundleOutFile + '.json';
+        var bundleInfoOutFile = bundleOutFile + '-json.js'; // .json file can't be loaded as an adjunct (ffs)
 
         bundleOutput = bundleOutput.pipe(bufferedTextTransform())// gathers together all the bundle JS, preparing for the next pipeline stage
             .pipe(requireStubTransform.pipelinePlugin(bundle, bundleInfoOutFile)) // transform the require stubs

--- a/internal/bundlegen.js
+++ b/internal/bundlegen.js
@@ -262,18 +262,20 @@ exports.doJSBundle = function(bundle, applyImports) {
             }
         });
 
+    var bundleOutFile = bundleTo + '/' + bundle.bundleOutputFile;
+
     if (applyImports) {
         var bufferedTextTransform = require('./pipeline-transforms/buffered-text-accumulator-transform');
         var requireStubTransform = require('./pipeline-transforms/require-stub-transform');
         var pack = require('browser-pack');
+        var bundleInfoOutFile = bundleOutFile + '.json';
 
         bundleOutput = bundleOutput.pipe(bufferedTextTransform())// gathers together all the bundle JS, preparing for the next pipeline stage
-            .pipe(requireStubTransform.pipelinePlugin(bundle.moduleMappings)) // transform the require stubs
+            .pipe(requireStubTransform.pipelinePlugin(bundle.moduleMappings, bundleInfoOutFile)) // transform the require stubs
             .pipe(pack()); // repack the bundle after the previous transform
     }
 
     var through = require('through2');
-    var bundleOutFile = bundleTo + '/' + bundle.bundleOutputFile;
     return bundleOutput.pipe(source(bundle.bundleOutputFile))
         .pipe(gulp.dest(bundleTo))
         .pipe(through.obj(function (bundle, encoding, callback) {

--- a/internal/bundlegen.js
+++ b/internal/bundlegen.js
@@ -271,7 +271,7 @@ exports.doJSBundle = function(bundle, applyImports) {
         var bundleInfoOutFile = bundleOutFile + '.json';
 
         bundleOutput = bundleOutput.pipe(bufferedTextTransform())// gathers together all the bundle JS, preparing for the next pipeline stage
-            .pipe(requireStubTransform.pipelinePlugin(bundle.moduleMappings, bundleInfoOutFile)) // transform the require stubs
+            .pipe(requireStubTransform.pipelinePlugin(bundle, bundleInfoOutFile)) // transform the require stubs
             .pipe(pack()); // repack the bundle after the previous transform
     }
 

--- a/internal/bundlegen.js
+++ b/internal/bundlegen.js
@@ -268,10 +268,9 @@ exports.doJSBundle = function(bundle, applyImports) {
         var bufferedTextTransform = require('./pipeline-transforms/buffered-text-accumulator-transform');
         var requireStubTransform = require('./pipeline-transforms/require-stub-transform');
         var pack = require('browser-pack');
-        var bundleInfoOutFile = bundleOutFile + '-json.js'; // .json file can't be loaded as an adjunct (ffs)
 
         bundleOutput = bundleOutput.pipe(bufferedTextTransform())// gathers together all the bundle JS, preparing for the next pipeline stage
-            .pipe(requireStubTransform.pipelinePlugin(bundle, bundleInfoOutFile)) // transform the require stubs
+            .pipe(requireStubTransform.pipelinePlugin(bundle, bundleOutFile)) // transform the require stubs
             .pipe(pack()); // repack the bundle after the previous transform
     }
 

--- a/internal/pipeline-transforms/require-stub-transform.js
+++ b/internal/pipeline-transforms/require-stub-transform.js
@@ -239,7 +239,8 @@ function getPackageInfoFromModulePath(modulePath) {
             var packageJson = require(packageJsonFile);
             return {
                 name: packageJson.name,
-                version: packageJson.version
+                version: packageJson.version,
+                path: toRelativePath(paths.parentDir(packageJsonFile))
             };
         }
     }

--- a/internal/pipeline-transforms/require-stub-transform.js
+++ b/internal/pipeline-transforms/require-stub-transform.js
@@ -414,7 +414,7 @@ function fullPathsToTruncatedPaths(metadata) {
         }
     }
 
-    return extractBundleMetadata(metadata.packEntries);
+    return metadata;
 }
 
 function fullPathsToIds(metadata) {
@@ -433,7 +433,7 @@ function fullPathsToIds(metadata) {
         }
     }
 
-    return extractBundleMetadata(metadata.packEntries);
+    return metadata;
 }
 
 function toRelativePath(path) {
@@ -455,6 +455,7 @@ function mapDependencyId(from, to, metadata) {
         dedupeSourceTo = 'arguments[4]["' + to + '"][0].apply(exports,arguments)';
     }
 
+    // Fixup the pack entries
     for (var i in metadata.packEntries) {
         if (metadata.packEntries.hasOwnProperty(i)) {
             var packEntry = metadata.packEntries[i];
@@ -473,6 +474,14 @@ function mapDependencyId(from, to, metadata) {
             }
         }
     }
+
+    // Fixup the moduleDef
+    var moduleDef = metadata.modulesDefs[from];
+    // Remove the moduleDef from the id it's currently known as.
+    delete metadata.modulesDefs[from];
+    // And reset the id 'to' the new id
+    moduleDef.id = to;
+    metadata.modulesDefs[to] = moduleDef;
 }
 
 function listAllModuleNames(modulesDefs) {

--- a/internal/pipeline-transforms/require-stub-transform.js
+++ b/internal/pipeline-transforms/require-stub-transform.js
@@ -70,9 +70,9 @@ function updateBundleStubs(packEntries, moduleMappings, skipFullPathToIdRewrite)
             if (!moduleMapping.fromSpec) {
                 moduleMapping.fromSpec = new ModuleSpec(moduleMapping.from);
             }
-            
+
             mapByPackageName(moduleMapping.fromSpec.moduleName, newSource);
-            
+
             // And check are there aliases that can be mapped...
             if (moduleMapping.config && moduleMapping.config.aliases) {
                 var aliases = moduleMapping.config.aliases;
@@ -121,15 +121,32 @@ function updateBundleStubs(packEntries, moduleMappings, skipFullPathToIdRewrite)
     unusedModules.forEach(function(moduleId) {
         removePackEntryById(metadata, moduleId);
     });
-    
+
+    verifyDepsOkay(metadata);
+
     if (!skipFullPathToIdRewrite && !args.isArgvSpecified('--full-paths')) {
         metadata = fullPathsToIds(metadata);
     }
-    
+
     // Keeping as it's handy for debug purposes.
     //require('fs').writeFileSync('./target/bundlepack.json', JSON.stringify(packEntries, undefined, 4));
-    
+
     return metadata;
+}
+
+function verifyDepsOkay(metadata) {
+    for (var i in metadata.packEntries) {
+        var packEntry = metadata.packEntries[i];
+
+        for (var module in packEntry.deps) {
+            if (packEntry.deps.hasOwnProperty(module)) {
+                var entryDepId = packEntry.deps[module];
+                if (!metadata.modulesDefs[entryDepId]) {
+                    console.log('[WARNING] Unexpected bundling error: packEntry ' + packEntry.id + ' depends on ' + entryDepId + ' but there is no moduleDef for that.');
+                }
+            }
+        }
+    }
 }
 
 function extractBundleMetadata(packEntries) {

--- a/internal/pipeline-transforms/require-stub-transform.js
+++ b/internal/pipeline-transforms/require-stub-transform.js
@@ -241,7 +241,8 @@ function getPackageInfoFromModulePath(modulePath) {
                 name: packageJson.name,
                 version: packageJson.version,
                 path: toRelativePath(paths.parentDir(packageJsonFile)),
-                repository: packageJson.repository
+                repository: packageJson.repository,
+                gitHead: packageJson.gitHead
             };
         }
     }

--- a/internal/pipeline-transforms/require-stub-transform.js
+++ b/internal/pipeline-transforms/require-stub-transform.js
@@ -356,25 +356,6 @@ function removeUnusedDeps(metadata, deps) {
     }
 }
 
-/**
- * Check all packs in the bundle, returning <code>true</code> if there's a pack
- * that contains a deduped reference to the supplied pack Id.
- * @param metadata Bundle metadata.
- * @param packId Pack Id.
- * @returns {boolean} 
- */
-function isReferencedByDedupe(metadata, packId) {
-    for (var i in metadata.packEntries) {
-        if (metadata.packEntries.hasOwnProperty(i)) {
-            var packEntry = metadata.packEntries[i];
-            if (packEntry.source === 'arguments[4]["' + packId + '"][0].apply(exports,arguments)') {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 function fullPathsToTruncatedPaths(metadata) {
     for (var i in metadata.packEntries) {
         if (metadata.packEntries.hasOwnProperty(i)) {

--- a/internal/pipeline-transforms/require-stub-transform.js
+++ b/internal/pipeline-transforms/require-stub-transform.js
@@ -206,7 +206,6 @@ function extractBundleMetadata(packEntries) {
     };
 
     addKnownAsToDefs(metadata);
-    addDependanciesToDefs(metadata);
 
     return metadata;
 }
@@ -229,8 +228,7 @@ function extractModuleDefs(packEntries) {
                 // resolve to different pack entries, depending on
                 // the context,
                 return (this.knownAs.indexOf(name) !== -1);
-            },
-            dependancies: []
+            }
         };
 
         if (typeof modulePath === 'string') {
@@ -273,31 +271,6 @@ function addKnownAsToDefs(metadata) {
                 }
                 if (moduleDef.knownAs.indexOf(module) === -1) {
                     moduleDef.knownAs.push(module);
-                }
-            }
-        }
-    }
-}
-
-function addDependanciesToDefs(metadata) {
-    for (var i in metadata.packEntries) {
-        var packEntry = metadata.packEntries[i];
-        var moduleDef = metadata.modulesDefs[packEntry.id];
-
-        if (!moduleDef) {
-            // This is only expected if it's the entry module.
-            if (!packEntry.entry) {
-                // No moduleDef created for moduleId with that pack ID. This module probably has
-                // nothing depending on it (and in reality, could probably be removed from the bundle).
-            }
-            continue;
-        }
-
-        for (var module in packEntry.deps) {
-            if (packEntry.deps.hasOwnProperty(module)) {
-                var entryDepId = packEntry.deps[module];
-                if (moduleDef.dependancies.indexOf(entryDepId) === -1) {
-                    moduleDef.dependancies.push(entryDepId);
                 }
             }
         }

--- a/internal/pipeline-transforms/require-stub-transform.js
+++ b/internal/pipeline-transforms/require-stub-transform.js
@@ -268,6 +268,9 @@ function addDependantsToDefs(metadata) {
                 if (moduleDef.dependants.indexOf(packEntry.id) === -1) {
                     moduleDef.dependants.push(packEntry.id);
                 }
+                if (moduleDef.knownAs.indexOf(module) === -1) {
+                    moduleDef.knownAs.push(module);
+                }
             }
         }
     }
@@ -424,7 +427,13 @@ function toRelativePath(path) {
 
 function mapDependencyId(from, to, metadata) {
     var dedupeSourceFrom = 'arguments[4]["' + from + '"][0].apply(exports,arguments)';
-    var dedupeSourceTo = 'arguments[4][' + to + '][0].apply(exports,arguments)';
+    var dedupeSourceTo;
+
+    if (typeof to === 'number') {
+        dedupeSourceTo = 'arguments[4][' + to + '][0].apply(exports,arguments)';
+    } else {
+        dedupeSourceTo = 'arguments[4]["' + to + '"][0].apply(exports,arguments)';
+    }
 
     for (var i in metadata.packEntries) {
         if (metadata.packEntries.hasOwnProperty(i)) {

--- a/internal/pipeline-transforms/require-stub-transform.js
+++ b/internal/pipeline-transforms/require-stub-transform.js
@@ -9,6 +9,7 @@ var unpack = require('browser-unpack');
 var browserifyTree = require('browserify-tree');
 var ModuleSpec = require('@jenkins-cd/js-modules/js/ModuleSpec');
 var logger = require('../logger');
+var pathPrefix = process.cwd() + '/';
 var node_modules_path = process.cwd() + '/node_modules/';
 var args = require('../args');
 var paths = require('../paths');
@@ -367,16 +368,11 @@ function isReferencedByDedupe(metadata, packId) {
 }
 
 function fullPathsToTruncatedPaths(metadata) {
-    var pathPrefix = process.cwd() + '/';
     for (var i in metadata.packEntries) {
         if (metadata.packEntries.hasOwnProperty(i)) {
             var packEntry = metadata.packEntries[i];
             var currentPackId = packEntry.id;
-            var truncatedPackId = currentPackId;
-
-            if (truncatedPackId.indexOf(pathPrefix) === 0) {
-                truncatedPackId = truncatedPackId.substring(pathPrefix.length);
-            }
+            var truncatedPackId = toRelativePath(currentPackId);
 
             mapDependencyId(currentPackId, truncatedPackId, metadata);
             packEntry.id = truncatedPackId;
@@ -403,6 +399,13 @@ function fullPathsToIds(metadata) {
     }
 
     return extractBundleMetadata(metadata.packEntries);
+}
+
+function toRelativePath(path) {
+    if (path.indexOf(pathPrefix) === 0) {
+        return path.substring(pathPrefix.length);
+    }
+    return path;
 }
 
 function mapDependencyId(from, to, metadata) {

--- a/internal/pipeline-transforms/require-stub-transform.js
+++ b/internal/pipeline-transforms/require-stub-transform.js
@@ -121,6 +121,7 @@ function updateBundleStubs(packEntries, moduleMappings, skipFullPathToIdRewrite)
             moduleDef.stubbed = {
                 importModule: importModule
             };
+            moduleDef.size = packEntry.source.length;
             // console.log('**** stubbing ' + packEntry.id + ' to import ' + importModule, moduleDef);
 
             // Need to look at all the original dependencies and
@@ -226,6 +227,7 @@ function extractModuleDefs(packEntries) {
             entry: packEntry.entry,
             packageInfo: getPackageInfoFromModulePath(modulePath),
             knownAs: [],
+            size: packEntry.source.length,
             isKnownAs: function(name) {
                 // Note that we need to be very careful about how we
                 // use this. Relative module names may obviously

--- a/internal/pipeline-transforms/require-stub-transform.js
+++ b/internal/pipeline-transforms/require-stub-transform.js
@@ -197,11 +197,12 @@ function extractModuleDefs(packEntries) {
 
         for (var moduleName in packEntry.deps) {
             if (packEntry.deps.hasOwnProperty(moduleName)) {
-                var packId = packEntry.deps[moduleName];
-                var moduleDef = modulesDefs[packId];
+                var modulePath = packEntry.deps[moduleName];
+                var moduleDef = modulesDefs[modulePath];
                 if (!moduleDef) {
                     moduleDef = {
-                        id: packId,
+                        id: modulePath,
+                        packageInfo: getPackageInfoFromModulePath(modulePath),
                         knownAs: [],
                         isKnownAs: function(name) {
                             // Note that we need to be very careful about how we
@@ -213,12 +214,12 @@ function extractModuleDefs(packEntries) {
                         dependants: [],
                         dependancies: []
                     };
-                    
-                    if (typeof packId === 'string') {
-                        moduleDef.node_module = nodeModulesRelPath(packId);
+
+                    if (typeof modulePath === 'string') {
+                        moduleDef.node_module = nodeModulesRelPath(modulePath);
                     }
-                    
-                    modulesDefs[packId] = moduleDef;
+
+                    modulesDefs[modulePath] = moduleDef;
                 }
                 if (moduleDef.knownAs.indexOf(moduleName) === -1) {
                     moduleDef.knownAs.push(moduleName);
@@ -228,6 +229,20 @@ function extractModuleDefs(packEntries) {
     }
 
     return modulesDefs;
+}
+
+function getPackageInfoFromModulePath(modulePath) {
+    if (typeof modulePath === 'string') {
+        var packageJsonFile = paths.findClosest('package.json', paths.parentDir(modulePath));
+        if (packageJsonFile) {
+            var packageJson = require(packageJsonFile);
+            return {
+                name: packageJson.name,
+                version: packageJson.version
+            };
+        }
+    }
+    return undefined;
 }
 
 function addDependantsToDefs(metadata) {

--- a/internal/pipeline-transforms/require-stub-transform.js
+++ b/internal/pipeline-transforms/require-stub-transform.js
@@ -240,7 +240,8 @@ function getPackageInfoFromModulePath(modulePath) {
             return {
                 name: packageJson.name,
                 version: packageJson.version,
-                path: toRelativePath(paths.parentDir(packageJsonFile))
+                path: toRelativePath(paths.parentDir(packageJsonFile)),
+                repository: packageJson.repository
             };
         }
     }

--- a/internal/templates/entry-module-wrapper.js
+++ b/internal/templates/entry-module-wrapper.js
@@ -12,7 +12,13 @@ function onFullfilled(moduleName) {
     }
     if (fullfilled.length === numStartupModules) {
         require('{{entrymodule}}');
-        onExec();
+        try {
+            if (onExec) {
+                onExec();
+            }
+        } catch (e) {
+            console.log('No onExec function, or an unexpected error executing it. Probably because of bundle.generateNoImportsBundle().');
+        }
     }
 }
 

--- a/internal/templates/entry-module.hbs
+++ b/internal/templates/entry-module.hbs
@@ -1,6 +1,34 @@
 var ___$$$___jsModules = require('@jenkins-cd/js-modules');
 
-___$$$___jsModules.whoami('{{#if bundle.bundleExportNamespace}}{{bundle.bundleExportNamespace}}:{{/if}}{{bundle.as}}');
+var whoami = '{{#if bundle.bundleExportNamespace}}{{bundle.bundleExportNamespace}}:{{/if}}{{bundle.as}}';
+
+___$$$___jsModules.whoami(whoami);
+
+
+function ___$$$___doExport(namespace, moduleName, module) {
+    ___$$$___jsModules.exportModule(namespace, moduleName, module);
+    if (window.sessionStorage) {
+        var keyPrefix = 'jenkins-cd/js-modules/export.tracking:';
+        if (!jenkinsCIGlobal._internal.trackMarker) {
+            jenkinsCIGlobal._internal.trackMarker = true;
+            var toRemove = [];
+            for (var i = 0; i < sessionStorage.length; i++) {
+                var key = sessionStorage.key(i);
+                if (key.indexOf(keyPrefix) === 0) {
+                    toRemove.push(key);
+                }
+            }
+            for (var i = 0; i < toRemove.length; i++) {
+                sessionStorage.removeItem(toRemove[i]);
+            }
+        }
+        var moduleBundleId = (namespace !== undefined ? (namespace + ':' + moduleName) : moduleName);
+        sessionStorage.setItem(keyPrefix + moduleBundleId, JSON.stringify({
+            at: Date.now(),
+            by: whoami
+        }))
+    }
+}
 
 /*** Start Module Exec Function ***************************************/
 function ___$$$___exec(onExec) {
@@ -11,14 +39,14 @@ function ___$$$___exec(onExec) {
 
 function ___$$$___doExports() {
     // Do exports, if any ....
-    {{#if entryExport}}___$$$___jsModules.exportModule({{entryExport.namespace}}, '{{bundle.as}}', {{entryExport.module}});{{/if}}
+    {{#if entryExport}}___$$$___doExport({{entryExport.namespace}}, '{{bundle.as}}', {{entryExport.module}});{{/if}}
 
     {{#if dependencyExports}}
         function doDependencyExport(module, normalizedPackageName, jsModuleNames) {
-            ___$$$___jsModules.exportModule(normalizedPackageName, jsModuleNames.patch, module);
-            ___$$$___jsModules.exportModule(normalizedPackageName, jsModuleNames.minor, module);
-            ___$$$___jsModules.exportModule(normalizedPackageName, jsModuleNames.major, module);
-            ___$$$___jsModules.exportModule(normalizedPackageName, jsModuleNames.any, module);
+            ___$$$___doExport(normalizedPackageName, jsModuleNames.patch, module);
+            ___$$$___doExport(normalizedPackageName, jsModuleNames.minor, module);
+            ___$$$___doExport(normalizedPackageName, jsModuleNames.major, module);
+            ___$$$___doExport(normalizedPackageName, jsModuleNames.any, module);
         }
 
         {{#each dependencyExports}}

--- a/internal/templates/entry-module.hbs
+++ b/internal/templates/entry-module.hbs
@@ -34,6 +34,7 @@ if (window.sessionStorage) {
     sessionStorage.setItem(trackKeyPrefix + 'load:' + whoami, JSON.stringify({
         event: 'load',
         bundleId: whoami,
+        bundlePath: '{{bundle.bundleInDir}}/{{bundle.bundleOutputFile}}',
         at: loadTimestamp,
         loadIdx: jenkinsCIGlobal._internal.bundleLoadIdx
     }));

--- a/internal/templates/entry-module.hbs
+++ b/internal/templates/entry-module.hbs
@@ -14,7 +14,7 @@ ___$$$___jsModules.whoami(whoami);
 
 // Clear out the session storage if this is the first
 // bundle to export on the page.
-var trackKeyPrefix = 'jenkins-cd/js-modules/export.tracking:';
+var trackKeyPrefix = 'jenkins-cd/js-modules/tracking/';
 if (window.sessionStorage && !jenkinsCIGlobal._internal.bundleLoadIdx) {
     jenkinsCIGlobal._internal.bundleLoadIdx = 0;
     var toRemove = [];
@@ -30,25 +30,31 @@ if (window.sessionStorage && !jenkinsCIGlobal._internal.bundleLoadIdx) {
 }
 jenkinsCIGlobal._internal.bundleLoadIdx++;
 
-var thisBundleLoadIdx = jenkinsCIGlobal._internal.bundleLoadIdx;
+if (window.sessionStorage) {
+    sessionStorage.setItem(trackKeyPrefix + 'load:' + whoami, JSON.stringify({
+        event: 'load',
+        bundleId: whoami,
+        at: loadTimestamp,
+        loadIdx: jenkinsCIGlobal._internal.bundleLoadIdx
+    }));
+}
 
 function ___$$$___doExport(namespace, moduleName, module) {
-    var moduleBundleId = (namespace !== undefined ? (namespace + ':' + moduleName) : moduleName);
+    var exportedModuleId = (namespace !== undefined ? (namespace + ':' + moduleName) : moduleName);
     try {
-        ___$$$___jsModules.requireModule(moduleBundleId);
+        ___$$$___jsModules.requireModule(exportedModuleId);
         // No exception => already exported. Shouldn't happen, but okay !!
         return;
     } catch (e) {
         // Not exported yet, hence exception on require. Okay to export !!
         ___$$$___jsModules.exportModule(namespace, moduleName, module);
         if (window.sessionStorage) {
-            sessionStorage.setItem(trackKeyPrefix + moduleBundleId, JSON.stringify({
+            sessionStorage.setItem(trackKeyPrefix + 'export:' + exportedModuleId, JSON.stringify({
+                event: 'export',
+                moduleId: exportedModuleId,
                 at: loadTimestamp,
-                by: {
-                    bundleId: whoami,
-                    bundleLoadIdx: thisBundleLoadIdx
-                }
-            }))
+                bundleId: whoami
+            }));
         }
     }
 }

--- a/internal/templates/entry-module.hbs
+++ b/internal/templates/entry-module.hbs
@@ -1,32 +1,55 @@
 var ___$$$___jsModules = require('@jenkins-cd/js-modules');
 
+if (!window.jenkinsCIGlobal) {
+    window.jenkinsCIGlobal = {};
+}
+if (!window.jenkinsCIGlobal._internal) {
+    window.jenkinsCIGlobal._internal = {};
+}
+
 var whoami = '{{#if bundle.bundleExportNamespace}}{{bundle.bundleExportNamespace}}:{{/if}}{{bundle.as}}';
+var loadTimestamp = Date.now();
 
 ___$$$___jsModules.whoami(whoami);
 
+// Clear out the session storage if this is the first
+// bundle to export on the page.
+var trackKeyPrefix = 'jenkins-cd/js-modules/export.tracking:';
+if (window.sessionStorage && !jenkinsCIGlobal._internal.bundleLoadIdx) {
+    jenkinsCIGlobal._internal.bundleLoadIdx = 0;
+    var toRemove = [];
+    for (var i = 0; i < sessionStorage.length; i++) {
+        var key = sessionStorage.key(i);
+        if (key.indexOf(trackKeyPrefix) === 0) {
+            toRemove.push(key);
+        }
+    }
+    for (var i = 0; i < toRemove.length; i++) {
+        sessionStorage.removeItem(toRemove[i]);
+    }
+}
+jenkinsCIGlobal._internal.bundleLoadIdx++;
+
+var thisBundleLoadIdx = jenkinsCIGlobal._internal.bundleLoadIdx;
 
 function ___$$$___doExport(namespace, moduleName, module) {
-    ___$$$___jsModules.exportModule(namespace, moduleName, module);
-    if (window.sessionStorage) {
-        var keyPrefix = 'jenkins-cd/js-modules/export.tracking:';
-        if (!jenkinsCIGlobal._internal.trackMarker) {
-            jenkinsCIGlobal._internal.trackMarker = true;
-            var toRemove = [];
-            for (var i = 0; i < sessionStorage.length; i++) {
-                var key = sessionStorage.key(i);
-                if (key.indexOf(keyPrefix) === 0) {
-                    toRemove.push(key);
+    var moduleBundleId = (namespace !== undefined ? (namespace + ':' + moduleName) : moduleName);
+    try {
+        ___$$$___jsModules.requireModule(moduleBundleId);
+        // No exception => already exported. Shouldn't happen, but okay !!
+        return;
+    } catch (e) {
+        // Not exported yet, hence exception on require. Okay to export !!
+        ___$$$___jsModules.exportModule(namespace, moduleName, module);
+        if (window.sessionStorage) {
+            sessionStorage.setItem(trackKeyPrefix + moduleBundleId, JSON.stringify({
+                at: loadTimestamp,
+                by: {
+                    bundleId: whoami,
+                    bundleLoadIdx: thisBundleLoadIdx
                 }
-            }
-            for (var i = 0; i < toRemove.length; i++) {
-                sessionStorage.removeItem(toRemove[i]);
-            }
+            }))
         }
-        var moduleBundleId = (namespace !== undefined ? (namespace + ':' + moduleName) : moduleName);
-        sessionStorage.setItem(keyPrefix + moduleBundleId, JSON.stringify({
-            at: Date.now(),
-            by: whoami
-        }))
     }
 }
 

--- a/internal/templates/export-module.hbs
+++ b/internal/templates/export-module.hbs
@@ -1,6 +1,4 @@
-var jsModules = require('@jenkins-cd/js-modules');
-
-jsModules.exportModule('{{normalizedPackageName}}', '{{jsModuleNames.patch}}', require('{{packageName}}'));
-jsModules.exportModule('{{normalizedPackageName}}', '{{jsModuleNames.minor}}', require('{{packageName}}'));
-jsModules.exportModule('{{normalizedPackageName}}', '{{jsModuleNames.major}}', require('{{packageName}}'));
-jsModules.exportModule('{{normalizedPackageName}}', '{{jsModuleNames.any}}', require('{{packageName}}'));
+___$$$___doExport('{{normalizedPackageName}}', '{{jsModuleNames.patch}}', require('{{packageName}}'));
+___$$$___doExport('{{normalizedPackageName}}', '{{jsModuleNames.minor}}', require('{{packageName}}'));
+___$$$___doExport('{{normalizedPackageName}}', '{{jsModuleNames.major}}', require('{{packageName}}'));
+___$$$___doExport('{{normalizedPackageName}}', '{{jsModuleNames.any}}', require('{{packageName}}'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder",
-  "version": "0.0.57-beta-1",
+  "version": "0.0.57-tf-beta-1",
   "description": "Jenkins CI JavaScript Build utilities.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder",
-  "version": "0.0.57-tf-beta-1",
+  "version": "0.0.57",
   "description": "Jenkins CI JavaScript Build utilities.",
   "main": "index.js",
   "scripts": {
@@ -65,8 +65,5 @@
   "devDependencies": {
     "@jenkins-cd/js-modules": "^0.0.8",
     "zombie": "^4.2.1"
-  },
-  "peerDependencies": {
-    "@jenkins-cd/js-modules": ">=0.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder",
-  "version": "0.0.56",
+  "version": "0.0.57-beta-1",
   "description": "Jenkins CI JavaScript Build utilities.",
   "main": "index.js",
   "scripts": {

--- a/spec/adjunctexternal-spec.js
+++ b/spec/adjunctexternal-spec.js
@@ -19,10 +19,10 @@ describe("adjunctexternal test", function () {
         
         // Check that the file contains an export for the module and that the names used in the export are
         // properly normalized i.e. no "@jenkins-cd" etc 
-        var indexOfPart = fileContents.indexOf("jsModules.exportModule('jenkins-cd-js-modules', 'jenkins-cd-js-modules@0.0.8', require('@jenkins-cd/js-modules'));");
+        var indexOfPart = fileContents.indexOf("___$$$___doExport('jenkins-cd-js-modules', 'jenkins-cd-js-modules@0.0.8', require('@jenkins-cd/js-modules'));");
         expect(indexOfPart !== -1).toBe(true);
         // And that the 'any' version is exported.
-        indexOfPart = fileContents.indexOf("jsModules.exportModule('jenkins-cd-js-modules', 'jenkins-cd-js-modules@any', require('@jenkins-cd/js-modules'));");
+        indexOfPart = fileContents.indexOf("___$$$___doExport('jenkins-cd-js-modules', 'jenkins-cd-js-modules@any', require('@jenkins-cd/js-modules'));");
         expect(indexOfPart !== -1).toBe(true);
     });
 });

--- a/spec/require-stub-transform-spec.js
+++ b/spec/require-stub-transform-spec.js
@@ -9,6 +9,7 @@ describe("require-stub-transform", function () {
         buildBrowserPack('module1.js', function (packEntries) {
             var metadata = transformModule.updateBundleStubs(packEntries, []);
 
+            //console.log(metadata.packEntries);
             //logMetadata(metadata);
 
             // Check we have defs for all modules. We won't have a def for
@@ -147,12 +148,12 @@ describe("require-stub-transform", function () {
             // We should have defs for all modules except module4, module5 and module6.
             var dedupeOnePackEntry = getPackEntryByName(metadata, './dedupe-one');
             var dedupeTwoPackEntry = getPackEntryByName(metadata, './dedupe-two');
-            
+
             expect(dedupeOnePackEntry).toBeDefined();
             expect(dedupeTwoPackEntry).toBeDefined();
             expect(dedupeOnePackEntry.id).toBe(2);
             expect(dedupeTwoPackEntry.id).toBe(3);
-            
+
             // The contents of both these modules are identical, causing browserify
             // to optimize by pointing dedupeTwoPackEntry to just point to dedupeOnePackEntry.
             // We ant to check that the module id was properly translated.
@@ -160,7 +161,7 @@ describe("require-stub-transform", function () {
 
             done()
         });
-    });    
+    });
 });
 
 function getPackEntryByName(metadata, name) {


### PR DESCRIPTION
Changes to get `js-builder` to generate and drop bundle metadata during build. This metadata can then be used during bundle runtime analysis via https://github.com/tfennelly/jenkins-js-modules-chrome-ext.