### PR TITLE
bug/lint and test failures dont fail the build

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -39,10 +39,6 @@ gulp.on('error', function(err) {
     process.stderr.write(err);
 });
 
-gulp.on('failed', function(err) {
-    process.exit(err);
-});
-
 // Lets pass on the options supplied, stripping off the
 // leading '--'.
 var options = {};
@@ -61,4 +57,8 @@ for (var i = 0; i < process.argv.length; i++) {
 delete options.tasks;
 options.cwd = cwd;
 
-gulp.run(tasks, options);
+gulp.run(tasks, options, function(error) {
+    if (error) {
+        process.exitCode = 1;
+    }
+});

--- a/spec/adjunctexternal-spec.js
+++ b/spec/adjunctexternal-spec.js
@@ -19,10 +19,10 @@ describe("adjunctexternal test", function () {
         
         // Check that the file contains an export for the module and that the names used in the export are
         // properly normalized i.e. no "@jenkins-cd" etc 
-        var indexOfPart = fileContents.indexOf("___$$$___doExport('jenkins-cd-js-modules', 'jenkins-cd-js-modules@0.0.8', require('@jenkins-cd/js-modules'));");
+        var indexOfPart = fileContents.indexOf("jsModules.exportModule('jenkins-cd-js-modules', 'jenkins-cd-js-modules@0.0.8', require('@jenkins-cd/js-modules'));");
         expect(indexOfPart !== -1).toBe(true);
         // And that the 'any' version is exported.
-        indexOfPart = fileContents.indexOf("___$$$___doExport('jenkins-cd-js-modules', 'jenkins-cd-js-modules@any', require('@jenkins-cd/js-modules'));");
+        indexOfPart = fileContents.indexOf("jsModules.exportModule('jenkins-cd-js-modules', 'jenkins-cd-js-modules@any', require('@jenkins-cd/js-modules'));");
         expect(indexOfPart !== -1).toBe(true);
     });
 });


### PR DESCRIPTION
When gulp-runner was ticked up to version 1.0.1, the "failed" event was removed. After this change, lint or test failures no longer actually failed the js-builder build. This uses the the callback passed to GulpRunner.run and set process.exitCode to non-zero (per Node docs).