### PR TITLE
Make eslint use async hints for gulp

### DIFF
--- a/index.js
+++ b/index.js
@@ -672,7 +672,7 @@ var tasks = {
     },
 
     lint: function() {
-        require('./internal/lint').exec(langConfig, lintConfig);
+        return require('./internal/lint').exec(langConfig, lintConfig);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "handlebars": "^3.0.3",
     "jasmine-reporters": "^2.0.6",
     "jshint": "^2.x",
+    "merge-stream": "^1.0.1",
     "minifyify": "^7.1.0",
     "ncp": "^2.0.0",
     "node-http-server": "^3.0.5",


### PR DESCRIPTION
eslint running against large code bases could fail with lint errors but not actually fail the build. I also noticed that the 'lint' task would begin and end immediately because proper async hints w/ gulp were not used.

Before changes:

```
[14:28:48] Starting 'lint'...
[14:28:49] 	- Using .eslintrc. Override by defining a .eslintrc in this folder.
[14:28:49] Finished 'lint' after 236 ms
[14:28:56] 
/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/config.js
  9:22  warning  Missing function expression name  func-names

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/redux/actions.js
  293:1   warning  Line 293 exceeds the maximum line length of 160  max-len
  320:1   warning  Line 320 exceeds the maximum line length of 160  max-len
  621:33  warning  Unexpected console statement                     no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/util/push-event-util.js
  10:26  warning  Missing function expression name  func-names

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/flow2/FlowManager.js
  160:13  warning  Unexpected console statement  no-console
  241:9   warning  Unexpected console statement  no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/github/GithubFlowManager.js
  222:29  warning  Unexpected console statement  no-console
  308:29  warning  Unexpected console statement  no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/github/api/GithubCreationApi.js
  28:1  warning  Line 28 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/github/api/mocks/ApiMock.js
   9:17  warning  Unexpected console statement  no-console
  21:17  warning  Unexpected console statement  no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/github/api/mocks/GithubCreationApiMock.js
  75:9  warning  Unexpected console statement  no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/Activity.jsx
  15:33  error    Missing trailing comma           comma-dangle
  52:30  warning  Unexpected string concatenation  prefer-template

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/MultiBranch.jsx
  67:1  warning  Line 67 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/PipelineRunGraph.jsx
  69:1  warning  Line 69 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/RunDetails.jsx
   51:1  warning  Line 51 exceeds the maximum line length of 160   max-len
  171:1  warning  Line 171 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
  104:1  warning  Line 104 exceeds the maximum line length of 160  max-len
  112:1  warning  Line 112 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/RunDetailsHeader.jsx
   97:51  warning  Unexpected string concatenation  prefer-template
  119:51  warning  Unexpected string concatenation  prefer-template

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/RunMessageCell.jsx
  32:1    warning  Line 32 exceeds the maximum line length of 160  max-len
  32:169  error    A space is required after '{'                   object-curly-spacing
  32:193  error    A space is required before '}'                  object-curly-spacing
  32:196  error    A space is required before closing bracket      react/jsx-space-before-closing
  33:20   error    Unexpected 'else' after 'return'                no-else-return
  38:55   error    Infix operators must be spaced                  space-infix-ops
  39:128  error    Missing semicolon                               semi

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/CreatePipelineScmListRenderer.jsx
  33:21  warning  Unexpected console statement  no-console
  61:25  warning  Unexpected console statement  no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/CreatePipelineStepsRenderer.jsx
  41:13  warning  Unexpected console statement  no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
  25:58  error  'testService' is defined but never used  no-unused-vars

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/git/GitIcon.jsx
  16:1  warning  Line 16 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/github/GithubIcon.jsx
  10:1  warning  Line 10 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/karaoke/components/InputStep.jsx
  103:1  warning  Line 103 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/github/steps/GithubCompleteStep.jsx
  133:60  warning  Unexpected string concatenation  prefer-template

✖ 38 problems (8 errors, 30 warnings)

macbook-15:blueocean-dashboard cmeyers$
```

After changes

```
[14:32:58] Starting 'lint'...
[14:32:58] 	- Using .eslintrc. Override by defining a .eslintrc in this folder.
[14:33:06] 
/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/config.js
  9:22  warning  Missing function expression name  func-names

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/redux/actions.js
  293:1   warning  Line 293 exceeds the maximum line length of 160  max-len
  320:1   warning  Line 320 exceeds the maximum line length of 160  max-len
  621:33  warning  Unexpected console statement                     no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/util/push-event-util.js
  10:26  warning  Missing function expression name  func-names

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/flow2/FlowManager.js
  160:13  warning  Unexpected console statement  no-console
  241:9   warning  Unexpected console statement  no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/github/GithubFlowManager.js
  222:29  warning  Unexpected console statement  no-console
  308:29  warning  Unexpected console statement  no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/github/api/GithubCreationApi.js
  28:1  warning  Line 28 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/github/api/mocks/ApiMock.js
   9:17  warning  Unexpected console statement  no-console
  21:17  warning  Unexpected console statement  no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/github/api/mocks/GithubCreationApiMock.js
  75:9  warning  Unexpected console statement  no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/Activity.jsx
  15:33  error    Missing trailing comma           comma-dangle
  52:30  warning  Unexpected string concatenation  prefer-template

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/MultiBranch.jsx
  67:1  warning  Line 67 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/PipelineRunGraph.jsx
  69:1  warning  Line 69 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/RunDetails.jsx
   51:1  warning  Line 51 exceeds the maximum line length of 160   max-len
  171:1  warning  Line 171 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/RunDetailsArtifacts.jsx
  104:1  warning  Line 104 exceeds the maximum line length of 160  max-len
  112:1  warning  Line 112 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/RunDetailsHeader.jsx
   97:51  warning  Unexpected string concatenation  prefer-template
  119:51  warning  Unexpected string concatenation  prefer-template

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/RunMessageCell.jsx
  32:1    warning  Line 32 exceeds the maximum line length of 160  max-len
  32:169  error    A space is required after '{'                   object-curly-spacing
  32:193  error    A space is required before '}'                  object-curly-spacing
  32:196  error    A space is required before closing bracket      react/jsx-space-before-closing
  33:20   error    Unexpected 'else' after 'return'                no-else-return
  38:55   error    Infix operators must be spaced                  space-infix-ops
  39:128  error    Missing semicolon                               semi

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/CreatePipelineScmListRenderer.jsx
  33:21  warning  Unexpected console statement  no-console
  61:25  warning  Unexpected console statement  no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/CreatePipelineStepsRenderer.jsx
  41:13  warning  Unexpected console statement  no-console

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/testing/TestCaseResultRow.jsx
  25:58  error  'testService' is defined but never used  no-unused-vars

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/github/GithubIcon.jsx
  10:1  warning  Line 10 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/git/GitIcon.jsx
  16:1  warning  Line 16 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/components/karaoke/components/InputStep.jsx
  103:1  warning  Line 103 exceeds the maximum line length of 160  max-len

/Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/src/main/js/creation/github/steps/GithubCompleteStep.jsx
  133:60  warning  Unexpected string concatenation  prefer-template

✖ 38 problems (8 errors, 30 warnings)

[14:33:06] Oops, there are some eslint errors/warnings:
[14:33:06] 	Warnings: 30
[14:33:06] 	Errors:   8
[14:33:06] There are eslint errors. Failing the build now. (--continueOnLint to continue on lint errors)
[14:33:06] ** try "gulp lint --fixLint" to fix some/all linting issues **

npm ERR! Darwin 15.6.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "lint"
npm ERR! node v6.10.2
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! blueocean-dashboard@0.0.1 lint: `jjsbuilder --tasks lint`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the blueocean-dashboard@0.0.1 lint script 'jjsbuilder --tasks lint'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the blueocean-dashboard package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     jjsbuilder --tasks lint
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs blueocean-dashboard
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls blueocean-dashboard
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/cmeyers/Development/code/sandbox/blueocean-plugin-scratch/blueocean-plugin-1/blueocean-dashboard/npm-debug.log
macbook-15:blueocean-dashboard cmeyers$ 
```