### PR TITLE
[update_preset] Drop es2015 package and use new dep for it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-builder",
-  "version": "0.0.60-SNAPSHOT-1",
+  "version": "0.0.61-SNAPSHOT",
   "description": "Jenkins CI JavaScript Build utilities.",
   "main": "index.js",
   "scripts": {
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@jenkins-cd/eslint-config-jenkins": "0.0.2",
-    "babel-preset-es2015": "6.5.0",
     "babelify": "7.3.0",
     "brfs": "1.4.3",
     "browser-pack": "6.0.1",
@@ -64,6 +63,7 @@
   },
   "devDependencies": {
     "@jenkins-cd/js-modules": "0.0.8",
+    "babel-preset-env": "1.6.0",
     "zombie": "4.2.1"
   }
 }


### PR DESCRIPTION
To get rid of

```
babel-preset-es2015@6.24.0: We're super 😸  excited that you're trying to use ES2015 syntax, but instead of continuing yearly presets 😭 , we recommend using babel-preset-env: npm install babel-preset-env. preset-env without options will compile ES2015+ down to ES5. And by targeting specific browsers, Babel can do less work and you can ship native ES2015+ to users 😎 ! Also, we are in the process of releasing v7, so give http://babeljs.io/blog/2017/09/12/planning-for-7.0 a read and test it! Thanks so much for using Babel 🙏 , please give us a follow @babeljs for updates, join slack.babeljs.io for discussion and help support at opencollective.com/babel
```