### PR TITLE
[JENKINS-50387] - Upgrade browserify to 13.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "brfs": "^1.4.3",
     "browser-pack": "^6.0.1",
     "browser-unpack": "^1.1.1",
-    "browserify": "^12.0.1",
+    "browserify": "^13.3.0",
     "browserify-transform-tools": "^1.4.2",
     "browserify-tree": "0.0.6",
     "decamelize": "^1.2.0",


### PR DESCRIPTION
The reasoning behind this is included in the Jira ticket. Tested the change by building the blueocean-core-js module. Link to Jira: https://issues.jenkins.io/browse/JENKINS-50387